### PR TITLE
Update compat bounds to support Dash v1.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,5 +7,5 @@ version = "0.5.0"
 Dash = "1b08a953-4be3-4667-9a23-3db579824955"
 
 [compat]
-Dash = "0.1.3"
+Dash = "0.1.3,1.0"
 julia = "1.2"


### PR DESCRIPTION
I think that DashDaq is compatible with the Dash v1.x series, so this PR updates the compat bounds.
Closes #4 